### PR TITLE
Add TransparentAI module and demo CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,18 @@ Should be some combination of
 - which model
 - what context (huge)
 - output
+
+## TransparentAI script
+
+`transparent_ai.py` exposes a `TransparentAI` class that forwards messages to an
+OpenAI chat model while returning the full message context. A small CLI in
+`main.py` demonstrates how the system works.
+
+Example:
+
+```bash
+python main.py "Explain transformers in two sentences" --context "Transformers are attention based" --dev-mode
+```
+
+If the `OPENAI_API_KEY` environment variable is not configured the script will
+return a stubbed response so the repository can be tested offline.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,31 @@
+"""Simple CLI demonstrating TransparentAI usage."""
+
+import argparse
+from transparent_ai import TransparentAI
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Transparent AI demo")
+    parser.add_argument("message", help="User message to send to the model")
+    parser.add_argument("--model", default="gpt-4o", help="Model to query")
+    parser.add_argument("--dev-mode", action="store_true", help="Bypass system prompt and context")
+    parser.add_argument(
+        "--context",
+        nargs="*",
+        default=None,
+        help="Optional context documents to supply",
+    )
+    args = parser.parse_args()
+
+    ai = TransparentAI(model=args.model, dev_mode=args.dev_mode)
+    result = ai.chat(args.message, context_docs=args.context)
+
+    print("MODEL:", result["model"])
+    print("MESSAGES:")
+    for msg in result["messages"]:
+        print(f"- {msg['role']}: {msg['content']}")
+    print("OUTPUT:", result["output"])
+
+
+if __name__ == "__main__":
+    main()

--- a/transparent_ai.py
+++ b/transparent_ai.py
@@ -1,0 +1,82 @@
+"""Transparent AI module.
+Provides TransparentAI class that interfaces with language models
+and exposes full context and model details for transparency.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import List, Dict, Any, Optional
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - openai may not be installed
+    OpenAI = None  # type: ignore
+
+
+@dataclass
+class TransparentAI:
+    """A small helper around the OpenAI API exposing full context.
+
+    Parameters
+    ----------
+    model: str
+        Model name to query, e.g. ``"gpt-4o"``.
+    system_prompt: str
+        Optional system instruction used when ``dev_mode`` is ``False``.
+    dev_mode: bool
+        If ``True`` only the user message is sent to the model, mimicking
+        direct access without additional instructions or retrieved context.
+    stub_response: str
+        Text returned when no OpenAI API key is configured. This allows the
+        module to be run in environments without network access during tests.
+    """
+
+    model: str = "gpt-4o"
+    system_prompt: str = "You are a helpful assistant."
+    dev_mode: bool = False
+    stub_response: str = "[stubbed response]"
+
+    def _call_model(self, messages: List[Dict[str, str]]) -> str:
+        """Send messages to the model and return the text completion.
+
+        Falls back to ``stub_response`` when the OpenAI client is not available
+        or no API key is configured.
+        """
+        if OpenAI is None or not os.getenv("OPENAI_API_KEY"):
+            return self.stub_response
+
+        client = OpenAI()
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            logprobs=True,
+        )
+        return response.choices[0].message.content
+
+    def chat(self, user_input: str, context_docs: Optional[List[str]] = None) -> Dict[str, Any]:
+        """Generate a response and return full transparency data.
+
+        Parameters
+        ----------
+        user_input: str
+            End user's message.
+        context_docs: list of str, optional
+            Additional context strings retrieved via RAG or search.
+
+        Returns
+        -------
+        dict
+            Dictionary with ``model``, ``messages`` and ``output`` keys.
+        """
+        messages: List[Dict[str, str]] = []
+        if not self.dev_mode:
+            messages.append({"role": "system", "content": self.system_prompt})
+            if context_docs:
+                context = "\n".join(context_docs)
+                messages.append({"role": "system", "content": f"Context:\n{context}"})
+        messages.append({"role": "user", "content": user_input})
+
+        output_text = self._call_model(messages)
+        return {"model": self.model, "messages": messages, "output": output_text}


### PR DESCRIPTION
## Summary
- Implement TransparentAI class to query OpenAI models while exposing full message context and a dev mode for direct model access
- Provide a CLI demo and README instructions for using the TransparentAI module

## Testing
- `python main.py "Hello" --context "This is RAG" --model gpt-4o`
- `python main.py "Hello" --dev-mode`
- `python -m py_compile transparent_ai.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688edc639a2c83228f129ae718f2baf5