### PR TITLE
Add TransparentAI wrapper with dev mode, CLI, and web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,43 @@
-# Chatbot and Dev tools to actually know what's going on inside the model
-Access to direct model if needed, or you **choose** to turn on, or send more context :D
+# Transparent AI
 
-## All outputs must be clearly explained as far as system prompt and RAG or search or anything the model does
-Should be some combination of
-- which model
-- what context (huge)
-- output
+Tools to inspect exactly what prompts and context reach a model and what it
+returns. The goal is to make model interactions auditable for developers.
+It can query both OpenAI hosted models and local ``ollama`` models.
+
+## Design Goals
+
+- **Which model**: easily switch between GPT-4o or any other supported model.
+- **What context**: show the final system prompt, retrieved documents and user
+  message.
+- **How output is generated**: expose the raw completion and token logprobs.
+- **Bypass guardrails**: a dev mode sends only the user message when needed.
+
+## Command Line
+
+```bash
+export OPENAI_API_KEY="sk-..."
+python transparent_cli.py "What is RAG?"
+python transparent_cli.py --docs docs.txt "Who wrote these docs?"
+```
+
+Use `--dev` to bypass the system prompt and any RAG context. Models may also be
+prefixed with `ollama/` to call a local model, e.g. `--model ollama/llama2`.
+
+## Web Interface
+
+For non-technical users install `gradio` and run the browser UI:
+
+```bash
+pip install gradio
+python transparent_web.py
+```
+
+Paste optional reference text into the RAG context box and toggle **Dev mode**
+for direct model access. The right-hand panel displays the full message list,
+token logprobs and total token count for each response.
+
+## Extending
+
+`TransparentAI` accepts a `rag_fn` callback for retrieving context. The included
+`simple_rag` is a placeholder; replace it with a search or database lookup to
+build a complete RAG system.

--- a/transparent_ai.py
+++ b/transparent_ai.py
@@ -1,0 +1,118 @@
+"""Transparent AI core module.
+
+Provides a wrapper around the OpenAI Chat Completions API (and optional local
+``ollama`` models) that exposes exactly which messages are sent to the model,
+returns log probabilities and token counts, and supports a developer bypass
+mode.
+
+Usage::
+
+    from transparent_ai import TransparentAI
+    ai = TransparentAI()
+    result = ai.generate("Explain transformers in 2 sentences.")
+    print(result["output"])
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+import json
+import urllib.request
+
+from openai import OpenAI
+
+
+@dataclass
+class TransparentAI:
+    """Small wrapper around OpenAI's API exposing prompts and logprobs."""
+
+    model: str = "gpt-4o"
+    system_prompt: str = "You are a helpful assistant."
+    rag_fn: Optional[Callable[[str], List[str]]] = None
+    client: OpenAI = field(default_factory=OpenAI)
+
+    def build_messages(self, user_input: str, dev_mode: bool) -> List[Dict[str, str]]:
+        """Constructs the message list sent to the model.
+
+        If ``dev_mode`` is True, only the raw user message is included. Otherwise
+        the system prompt and any retrieved RAG context is prepended.
+        """
+        messages: List[Dict[str, str]] = []
+        if dev_mode:
+            messages.append({"role": "user", "content": user_input})
+            return messages
+
+        messages.append({"role": "system", "content": self.system_prompt})
+        if self.rag_fn:
+            for chunk in self.rag_fn(user_input):
+                messages.append({"role": "system", "content": chunk})
+        messages.append({"role": "user", "content": user_input})
+        return messages
+
+    def generate(self, user_input: str, dev_mode: bool = False) -> Dict[str, Any]:
+        """Generates a response from either OpenAI or a local ``ollama`` model.
+
+        Returns a dictionary containing the final output, model used, messages
+        sent and log probabilities/token counts when available. Local models are
+        selected by prefixing the model name with ``"ollama/"``.
+        """
+        messages = self.build_messages(user_input, dev_mode)
+        if self.model.startswith("ollama/"):
+            local_model = self.model.split("/", 1)[1]
+            prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
+            req = urllib.request.Request(
+                "http://localhost:11434/api/generate",
+                data=json.dumps({"model": local_model, "prompt": prompt}).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+            output = data.get("response", "")
+            return {
+                "model": local_model,
+                "output": output,
+                "logprobs": None,
+                "messages": messages,
+                "tokens": None,
+            }
+
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            logprobs=True,
+        )
+        choice = response.choices[0]
+        token_count = len(choice.logprobs["content"]) if choice.logprobs else 0
+        return {
+            "model": response.model,
+            "output": choice.message.content,
+            "logprobs": choice.logprobs,
+            "messages": messages,
+            "tokens": token_count,
+        }
+
+
+def simple_rag(query: str) -> List[str]:
+    """Very small placeholder RAG function.
+
+    In a real system this would issue a search and return relevant context
+    chunks. Here we simply return an empty list to illustrate the interface.
+    """
+    return []
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+
+    question = sys.argv[1] if len(sys.argv) > 1 else "What is RAG?"
+    dev_mode = bool(os.environ.get("DEV_MODE"))
+    ai = TransparentAI(rag_fn=simple_rag)
+    result = ai.generate(question, dev_mode=dev_mode)
+    print("MODEL:", result["model"])
+    print("OUTPUT:", result["output"])
+    print("TOKENS:", result.get("tokens"))
+    print("LOGPROBS:", result.get("logprobs"))
+    print("MESSAGES:", result["messages"])

--- a/transparent_cli.py
+++ b/transparent_cli.py
@@ -1,0 +1,47 @@
+"""Minimal command-line interface for TransparentAI.
+
+The ``--model`` argument accepts either an OpenAI model name (e.g. ``gpt-4o``)
+or ``ollama/<local-model>`` to query a locally running ``ollama`` instance.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Callable, List
+
+from transparent_ai import TransparentAI
+
+
+def build_rag_from_file(path: Path) -> Callable[[str], List[str]]:
+    """Return a RAG function that feeds the entire file as context."""
+
+    text = path.read_text(encoding="utf-8")
+
+    def _rag(_query: str) -> List[str]:
+        return [text]
+
+    return _rag
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="TransparentAI CLI")
+    parser.add_argument("prompt", nargs="?", default="What is RAG?", help="Question to ask")
+    parser.add_argument("--model", default="gpt-4o", help="Model name or ollama/<model>")
+    parser.add_argument("--dev", action="store_true", help="Bypass system prompt and RAG")
+    parser.add_argument("--docs", type=Path, help="Path to text file for RAG context")
+    args = parser.parse_args()
+
+    rag_fn = build_rag_from_file(args.docs) if args.docs else None
+
+    ai = TransparentAI(model=args.model, rag_fn=rag_fn)
+    result = ai.generate(args.prompt, dev_mode=args.dev)
+    print("MODEL:", result["model"])
+    print("OUTPUT:\n", result["output"])
+    print("MESSAGES:\n", result["messages"])
+    print("LOGPROBS:\n", result.get("logprobs"))
+    print("TOKENS:\n", result.get("tokens"))
+
+
+if __name__ == "__main__":
+    main()

--- a/transparent_web.py
+++ b/transparent_web.py
@@ -1,0 +1,59 @@
+"""Gradio web interface for TransparentAI.
+
+Allows non-technical users to interact with the wrapper from a browser.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import gradio as gr
+
+from transparent_ai import TransparentAI
+
+
+def ask(question: str, model: str, dev_mode: bool, docs: str) -> Tuple[str, List[dict], dict, str, int]:
+    """Run a query through ``TransparentAI`` and return detailed data."""
+    rag_fn = (lambda _query: [docs]) if docs else None
+    ai = TransparentAI(model=model, rag_fn=rag_fn)
+    result = ai.generate(question, dev_mode=dev_mode)
+    return (
+        result["output"],
+        result["messages"],
+        result.get("logprobs"),
+        result["model"],
+        result.get("tokens", 0),
+    )
+
+
+def main() -> None:
+    with gr.Blocks() as demo:
+        gr.Markdown("# Transparent AI")
+        with gr.Row():
+            with gr.Column():
+                question = gr.Textbox(label="Question", lines=2)
+                docs = gr.Textbox(
+                    label="RAG Context (optional)",
+                    lines=2,
+                    placeholder="Paste reference text here",
+                )
+                model = gr.Textbox(label="Model", value="gpt-4o")
+                dev = gr.Checkbox(label="Dev mode (bypass system prompt)")
+                run = gr.Button("Run")
+                used_model = gr.Textbox(label="Model used", interactive=False)
+            with gr.Column():
+                output = gr.Textbox(label="Output", lines=10)
+            with gr.Column():
+                messages = gr.JSON(label="Messages")
+                logprobs = gr.JSON(label="Log probabilities")
+                tokens = gr.Number(label="Token count", precision=0)
+        run.click(
+            ask,
+            [question, model, dev, docs],
+            [output, messages, logprobs, used_model, tokens],
+        )
+    demo.launch()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Introduce `TransparentAI` helper around OpenAI's Chat Completions API that exposes prompts, log probabilities, token counts, and supports both dev mode and optional local `ollama` models
- Provide a `transparent_cli.py` script for minimal command-line usage with optional file-based RAG context and local model invocation
- Add a Gradio-powered `transparent_web.py` interface so non-technical users can inspect prompts, outputs, and token statistics from a browser
- Document CLI and web usage, including dev mode, local `ollama` model prefix, and remove Slack bot references to focus on consumer and developer workflows

## Testing
- `python -m py_compile transparent_ai.py transparent_cli.py transparent_web.py`


------
https://chatgpt.com/codex/tasks/task_e_688edc639a2c83228f129ae718f2baf5